### PR TITLE
Feat: geração de pdf

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
     "react-to-pdf": "^0.0.14",
+    "react-to-print": "^2.12.6",
     "react-toast-notifications": "^2.4.4",
     "sass": "^1.32.11",
     "web-vitals": "^1.0.1"

--- a/src/components/PDF/PDF.js
+++ b/src/components/PDF/PDF.js
@@ -1,13 +1,13 @@
-import React from 'react';
-import Pdf from 'react-to-pdf';
+import React, { useRef } from 'react';
+import { useReactToPrint } from 'react-to-print';
 import './PDF.scss';
+import { FiPrinter } from 'react-icons/fi';
 
-const ref = React.createRef();
-
-function PDF() {
-  return (
-    <div>
-      <div className="pdf-external-div" ref={ref}>
+// eslint-disable-next-line react/prefer-stateless-function
+class ComponentToPrint extends React.Component {
+  render() {
+    return (
+      <div className="pdf-external-div">
         <div className="pdf-header">
           <div className="pdf-image">
             <img
@@ -29,14 +29,14 @@ function PDF() {
           <div className="pdf-title">DECLARAÇÃO</div>
           <p className="pdf-dedicate">
             Declaro, para os devidos fins, que ANDERSON JÚNIOR DOS SANTOS,
-            matrícula nº 2018700680, é aluno regularmente matriculado no Programa
-            de Pós-Graduação em Engenharia Mecânica, nível Doutorado, da
-            Universidade Federal de Minas Gerais, frequentando regularmente as
-            atividades desde março de 2018. Declaro, ainda, que o referido aluno é
-            bolsista do Conselho Nacional de Desenvolvimento Científico e
-            Tecnológico (CNPq), recebendo, mensalmente, a quantia correspondente a
-            01 (uma) bolsa de doutorado, no valor de R$ 1500 (um mil, quinhentos
-            reais), de acordo com a legislação vigente.
+            matrícula nº 2018700680, é aluno regularmente matriculado no
+            Programa de Pós-Graduação em Engenharia Mecânica, nível Doutorado,
+            da Universidade Federal de Minas Gerais, frequentando regularmente
+            as atividades desde março de 2018. Declaro, ainda, que o referido
+            aluno é bolsista do Conselho Nacional de Desenvolvimento Científico
+            e Tecnológico (CNPq), recebendo, mensalmente, a quantia
+            correspondente a 01 (uma) bolsa de doutorado, no valor de R$ 1500
+            (um mil, quinhentos reais), de acordo com a legislação vigente.
           </p>
           <p className="pdf-date">Belo Horizonte, 13 de maio de 2021</p>
           <div className="pdf-coordinator">
@@ -45,23 +45,34 @@ function PDF() {
             <p>em Engenharia Mecânica da UFMG</p>
           </div>
           <p className="pdf-observation">
-            OBS: Sugiro que os dados a serem preenchidos
-            pela secretaria fossem os de destaque.
-            Se possível o campo permitir a digitação de mais dados caso necessário.
-            Os demais itens serão gerados automáticos correto?
+            OBS: Sugiro que os dados a serem preenchidos pela secretaria fossem
+            os de destaque. Se possível o campo permitir a digitação de mais
+            dados caso necessário. Os demais itens serão gerados automáticos
+            correto?
           </p>
         </div>
       </div>
-
-      <Pdf targetRef={ref} filename="documento.pdf">
-        {({ toPdf }) => (
-          <button type="button" onClick={toPdf}>
-            BAIXAR
-          </button>
-        )}
-      </Pdf>
-    </div>
-  );
+    );
+  }
 }
 
-export default PDF;
+const PDFPage = () => {
+  const componentRef = useRef();
+  const handlePrint = useReactToPrint({
+    content: () => componentRef.current,
+  });
+
+  return (
+    <div>
+      <div className="print-button" role="button" tabIndex="0" onClick={handlePrint} onKeyDown={handlePrint}>
+        <div className="print-button-text">
+          <FiPrinter className="print-icon" size={25} />
+          Imprimir
+        </div>
+      </div>
+      <ComponentToPrint ref={componentRef} />
+    </div>
+  );
+};
+
+export default PDFPage;

--- a/src/components/PDF/PDF.scss
+++ b/src/components/PDF/PDF.scss
@@ -4,13 +4,13 @@
     align-items: center;
     width: 100%;
     height: 100%;
-    padding: 10%;
+    padding: 5%;
   }
   .pdf-header{
     display: flex;
     align-items: center;
     justify-content: space-between;
-    width:70%;
+    width:75%;
     height: 20vh;
 
     .pdf-image {
@@ -54,7 +54,7 @@
         margin: 2%;
     }
     .pdf-coordinator {
-        margin-top: 6%;
+        margin-top: 5%;
         p{
             text-align: center;
             font-size: 1.3em;
@@ -62,12 +62,27 @@
         }
     }
     .pdf-observation {
-        margin-top: 5%;
-        margin-bottom: 5%;
-        width: 50%;
+        margin-top: 4%;
+        margin-bottom: 4%;
+        width: 55%;
         text-align: center;
         font-weight: bold;
         font-size: 1.3em;
+    }
+  }
+  .print-button {
+    cursor: pointer;
+    background: linear-gradient(45deg, #04133a, #092161, #04133a);
+
+    .print-button-text {
+        display: flex;
+        align-items: center;
+        color: white;
+        padding: 1% 2%;
+
+        .print-icon {
+            margin: 0 5px 0 5px;
+        }
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10063,6 +10063,13 @@ react-to-pdf@^0.0.14:
     html2canvas "1.0.0-alpha.12"
     jspdf "^2.3.1"
 
+react-to-print@^2.12.6:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-2.12.6.tgz#ac4537e12528ce865a1a652dcdfb19c5b20c9cce"
+  integrity sha512-O4hpQZX8pOd3W910n+WkT9Jvpd3tFcEWqTFHrm69bCGI/Nh5g2CoLrzaXObQW9BA9mK1K4+3qG88Q6DAJs+oWg==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-toast-notifications@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/react-toast-notifications/-/react-toast-notifications-2.4.4.tgz#a4b46195b437f312d72f552073957e3a1916f1ab"


### PR DESCRIPTION
Foi necessário remover a regra de utilizar apenas componentes funcionais através do comentário "// eslint-disable-next-line react/prefer-stateless-function" uma vez que a biblioteca utilizada apenas aceitas componentes de classe.