### PR TITLE
Ajustes na inscrição nos PSs e no CSS das listas de estudante e disciplina isolada

### DIFF
--- a/src/components/Inscritos/InscritosPS/InscritoPS.scss
+++ b/src/components/Inscritos/InscritosPS/InscritoPS.scss
@@ -12,6 +12,7 @@
   justify-content: center;
   min-width: 50px;
 }
+
 .nomeInscrito {
   display: flex;
   align-items: center;
@@ -30,9 +31,32 @@
   }
 
   @media (max-width:400px) {
-    width: 50%;
+    width: 40%;
   }
 }
+
+.nomeDisciplina {
+  display: flex;
+  align-items: center;
+  font-family: Montserrat;
+  font-size: 18px;
+  width: 50%;
+
+  p {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  @media(max-width: 500px){
+    font-size: 12px;
+  }
+
+  @media (max-width:400px) {
+    width: 60%;
+  }
+}
+
 .trash {
   cursor: pointer;
   width: 5%;

--- a/src/components/Isolateds/Isolateds.js
+++ b/src/components/Isolateds/Isolateds.js
@@ -15,7 +15,7 @@ function Isolateds({ isolated }) {
   return (
     <>
       <div className="linhaInscrito">
-        <div className="nomeInscrito">
+        <div className="nomeDisciplina">
           <IconContext.Provider value={{ size: 50 }}>
             <BiBookBookmark className="isoPsIcon" />
           </IconContext.Provider>

--- a/src/pages/FormDis/FormDis.js
+++ b/src/pages/FormDis/FormDis.js
@@ -67,18 +67,18 @@ function FormDis() {
 
     e.preventDefault();
     if (
-      dados.candidate_name.length > 3 &&
-      dados.candidate_cpf.length > 3 &&
-      dados.candidate_identity.length > 3 &&
+      dados.candidate_name.length >= 1 &&
+      dados.candidate_cpf.length >= 1 &&
+      dados.candidate_identity.length >= 1 &&
       dados.candidate_expedition !== "" &&
-      dados.candidate_nationality.length > 3 &&
-      dados.candidate_mother_name.length > 3 &&
-      dados.candidate_father_name.length > 3 &&
-      dados.candidate_civil_state.length > 3 &&
+      dados.candidate_nationality.length >= 1 &&
+      dados.candidate_mother_name.length >= 1 &&
+      dados.candidate_father_name.length >= 1 &&
+      dados.candidate_civil_state.length >= 1 &&
       dados.candidate_birth !== "" &&
-      dados.candidate_race.length > 3 &&
-      dados.candidate_gender.length > 3 &&
-      dados.candidate_voter_title.length > 3 &&
+      dados.candidate_race.length >= 1 &&
+      dados.candidate_gender.length >= 1 &&
+      dados.candidate_voter_title.length >= 1 &&
       dados.candidate_zone_title !== "" &&
       dados.candidate_section_title !== "" &&
       dados.candidate_street !== "" &&
@@ -91,14 +91,14 @@ function FormDis() {
       dados.candidate_district !== "" &&
       dados.candidate_state !== "" &&
       dados.candidate_adress_num !== "" &&
-      dados.candidate_country.length >= 3 &&
-      dados.candidate_cep.length > 3 &&
+      dados.candidate_country.length >= 1 &&
+      dados.candidate_cep.length >= 1 &&
       dados.candidate_grade_date_begin !== "" &&
       dados.candidate_grade_date_end !== "" &&
-      dados.candidate_email.length > 3 &&
-      dados.candidate_phone_number.length > 3 &&
+      dados.candidate_email.length >= 1 &&
+      dados.candidate_phone_number.length >= 1 &&
       dados.candidate_university !== "" &&
-      dados.candidate_graduation.length > 3 &&
+      dados.candidate_graduation.length >= 1 &&
       files.length === 5 &&
       (dados.first_discipline_isolated &&
       dados.first_discipline_isolated !== dados.second_discipline_isolated &&

--- a/src/pages/FormPs/FormPs.js
+++ b/src/pages/FormPs/FormPs.js
@@ -72,18 +72,18 @@ function FormPs() {
   const handleClick = async (e, dados) => {
     e.preventDefault();
     if (
-      dados.candidate_name.length > 3 &&
-      dados.candidate_cpf.length > 3 &&
-      dados.candidate_identity.length > 3 &&
+      dados.candidate_name.length >= 1 &&
+      dados.candidate_cpf.length >= 1 &&
+      dados.candidate_identity.length >= 1 &&
       dados.candidate_expedition !== "" &&
       dados.candidate_mother_name !== "" &&
       dados.candidate_father_name !== "" &&
-      dados.candidate_nationality.length > 3 &&
-      dados.candidate_civil_state.length > 3 &&
-      dados.candidate_birth.length > 3 &&
-      dados.candidate_race.length > 3 &&
-      dados.candidate_gender.length > 3 &&
-      dados.candidate_voter_title.length > 3 &&
+      dados.candidate_nationality.length >= 1 &&
+      dados.candidate_civil_state.length >= 1 &&
+      dados.candidate_birth.length >= 1 &&
+      dados.candidate_race.length >= 1 &&
+      dados.candidate_gender.length >= 1 &&
+      dados.candidate_voter_title.length >= 1 &&
       dados.candidate_zone_title !== "" &&
       dados.candidate_section_title !== "" &&
       dados.candidate_street !== "" &&
@@ -94,10 +94,10 @@ function FormPs() {
       dados.candidate_district !== "" &&
       dados.candidate_grade_date_begin !== "" &&
       dados.candidate_grade_date_end !== "" &&
-      dados.candidate_country.length > 3 &&
-      dados.candidate_cep.length > 3 &&
-      dados.candidate_email.length > 3 &&
-      dados.candidate_phone_number.length > 3 &&
+      dados.candidate_country.length >= 1 &&
+      dados.candidate_cep.length >= 1 &&
+      dados.candidate_email.length >= 1 &&
+      dados.candidate_phone_number.length >= 1 &&
       dados.candidate_university !== "" &&
       dados.candidate_grade_obtained !== "" &&
       dados.candidate_study_regimen !== "" &&

--- a/src/pages/StudentsList/StudentList.scss
+++ b/src/pages/StudentsList/StudentList.scss
@@ -16,7 +16,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  margin: 0px 50px;
+  margin: 10px 50px;
   h1 {
     text-align: center;
     margin-bottom: 0.2em;
@@ -52,7 +52,7 @@
   border-radius: 0px 0px 8px 8px;
   padding: 10px;
   box-shadow: 0px 3px 5px 0px #C4C4C4;
-  max-height: 280px;
+  max-height: 500px;
   overflow: auto;
 }
 

--- a/src/pages/StudentsList/StudentList.scss
+++ b/src/pages/StudentsList/StudentList.scss
@@ -52,6 +52,7 @@
   border-radius: 0px 0px 8px 8px;
   padding: 10px;
   box-shadow: 0px 3px 5px 0px #C4C4C4;
+  height: 50vh;
   max-height: 500px;
   overflow: auto;
 }
@@ -86,12 +87,12 @@
 @media (max-width: 820px) {
   .studentList-LeftContainer {
     margin: 0px;
+    padding: 10px 10px;
   }
 }
 
 @media (max-width:680px){
   .studentList-LeftContainer {
-    padding: 50px 5px;
     h1 {
       font-size: 35px;
     }

--- a/src/pages/forgetPass/Confirmation/Confirmation.scss
+++ b/src/pages/forgetPass/Confirmation/Confirmation.scss
@@ -59,16 +59,15 @@ h2 {
   border-radius: 15px;
   margin-top: 30px;
   margin-bottom: 30px;
-
+  gap: 20px;
 }
 
 .text{
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom:2vh ; 
-
 }
+
 .MuiFormControl-root.MuiTextField-root.campinho {
   margin-bottom: 25px;
   width: 85%;


### PR DESCRIPTION
Diminui o número necessário de caracteres nas inscrições de 3 para 1. Arrumei o CSS da lista de estudantes e disciplinas isoladas, como estavam usando o mesmo css, criei uma nova tag para os nomes das disciplinas isoladas, precisavam ocupar um espaço maior que o nome na lista de estudantes.